### PR TITLE
Add generic entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
         "featuretools_initialize": [
             "initialize = alteryx_open_src_update_checker.functions:initialize"
         ],
+        "alteryx_open_src_initialize": [
+            "initialize = alteryx_open_src_update_checker.functions:initialize"
+        ],
     },
     long_description=long_description,
     long_description_content_type='text/markdown'


### PR DESCRIPTION
Add additional entry point that is more generic than 'featuretools_initialize'. Keep the 'featuretools_initialize' entry point for backwards compatibility. 