### PR TITLE
Update warnings to not change user settings

### DIFF
--- a/alteryx_open_src_update_checker/functions.py
+++ b/alteryx_open_src_update_checker/functions.py
@@ -36,4 +36,6 @@ def check_version(library='featuretools', version=None, headers={}):
 
     if not is_latest:
         msg = "%s is out-of-date: installed == %s, latest == %s" % (library, version, latest_version)
+    with warnings.catch_warnings():
+        warnings.simplefilter('always')
         warnings.warn(msg)

--- a/alteryx_open_src_update_checker/functions.py
+++ b/alteryx_open_src_update_checker/functions.py
@@ -13,7 +13,10 @@ def initialize(library='featuretools'):
 
 def check_version(library='featuretools', version=None, headers={}):
     update_check = os.environ.get('ALTERYX_OPEN_SRC_UPDATE_CHECKER', True)
-    warnings.simplefilter('ignore')
+
+    # Use append=False when setting simplefilter so we know filter gets added
+    # to the start of the filters list and we can remove later with pop
+    warnings.simplefilter('ignore', append=False)
     try:
         lib = import_module(library)
     except Exception:
@@ -36,6 +39,8 @@ def check_version(library='featuretools', version=None, headers={}):
 
     if not is_latest:
         msg = "%s is out-of-date: installed == %s, latest == %s" % (library, version, latest_version)
-        warnings.simplefilter('always')
+        # Use append=False when setting simplefilter so we know filter gets added
+        # to the start of the filters list and we can remove later with pop
+        warnings.simplefilter('always', append=False)
         warnings.warn(msg)
         warnings.filters.pop(0)

--- a/alteryx_open_src_update_checker/functions.py
+++ b/alteryx_open_src_update_checker/functions.py
@@ -13,15 +13,11 @@ def initialize(library='featuretools'):
 
 def check_version(library='featuretools', version=None, headers={}):
     update_check = os.environ.get('ALTERYX_OPEN_SRC_UPDATE_CHECKER', True)
-
-    # Use append=False when setting simplefilter so we know filter gets added
-    # to the start of the filters list and we can remove later with pop
-    warnings.simplefilter('ignore', append=False)
     try:
         lib = import_module(library)
     except Exception:
         return
-    warnings.filters.pop(0)
+
     if version is None:
         version = lib.__version__
 
@@ -39,8 +35,4 @@ def check_version(library='featuretools', version=None, headers={}):
 
     if not is_latest:
         msg = "%s is out-of-date: installed == %s, latest == %s" % (library, version, latest_version)
-        # Use append=False when setting simplefilter so we know filter gets added
-        # to the start of the filters list and we can remove later with pop
-        warnings.simplefilter('always', append=False)
         warnings.warn(msg)
-        warnings.filters.pop(0)

--- a/alteryx_open_src_update_checker/functions.py
+++ b/alteryx_open_src_update_checker/functions.py
@@ -13,12 +13,12 @@ def initialize(library='featuretools'):
 
 def check_version(library='featuretools', version=None, headers={}):
     update_check = os.environ.get('ALTERYX_OPEN_SRC_UPDATE_CHECKER', True)
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        try:
-            lib = import_module(library)
-        except Exception:
-            return
+    warnings.simplefilter('ignore')
+    try:
+        lib = import_module(library)
+    except Exception:
+        return
+    warnings.filters.pop(0)
     if version is None:
         version = lib.__version__
 
@@ -36,6 +36,6 @@ def check_version(library='featuretools', version=None, headers={}):
 
     if not is_latest:
         msg = "%s is out-of-date: installed == %s, latest == %s" % (library, version, latest_version)
-    with warnings.catch_warnings():
         warnings.simplefilter('always')
         warnings.warn(msg)
+        warnings.filters.pop(0)

--- a/alteryx_open_src_update_checker/functions.py
+++ b/alteryx_open_src_update_checker/functions.py
@@ -5,8 +5,6 @@ from threading import Thread
 
 from .utils import get_response_json
 
-warnings.simplefilter("always")
-
 
 def initialize(library='featuretools'):
     bg_thread = Thread(target=check_version, kwargs={'library': library})


### PR DESCRIPTION
Update to always follow users warnings filter settings, so if users are filtering out warnings, they might not see the update warning. Previously we were changing the users warning behavior without giving them the ability to suppress the warning.